### PR TITLE
fix Java 8 dependency, now compiles under Java 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ info
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# IntelliJ project files
 *.iml

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ info
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+*.iml

--- a/src/main/java/org/piwik/java/tracking/CustomVariableList.java
+++ b/src/main/java/org/piwik/java/tracking/CustomVariableList.java
@@ -6,20 +6,19 @@
  */
 package org.piwik.java.tracking;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  *
  * @author brettcsorba
  */
 class CustomVariableList{
-    private final Map<Integer, CustomVariable> map = new HashMap<>();
+    private final ConcurrentHashMap<Integer, CustomVariable> map = new ConcurrentHashMap<>();
 
     void add(CustomVariable cv){
         boolean found = false;


### PR DESCRIPTION
This library _almost_ compiles under Java 7, but `java.util.Map` lacks a `putIfAbsent` method (added in Java 8). If we replace the regular `Map` with a `ConcurrentHashMap` (which does have this method), then it compiles fine.
